### PR TITLE
Advance to Stage 2 or 2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Champion: Eemeli Aro
 
-Stage: 1
+Stage: 2
 
 Presentations:
 - [For Stage 1](https://docs.google.com/presentation/d/1gunNRRXJNdDwqTHh-XjV3ueI8PFasRI9WcF4KfWvxE0/edit?usp=sharing) (2025.05)


### PR DESCRIPTION
I'll be presenting the proposal for stage advancement at the 2025.07 TC39 meeting and its preceding TC39-TG2 meeting.

On the TC39 Numerics calls, @sffc and @gibson042 have expressed interest and availability to act as its reviews for Stage 2.7 acceptance. If the TC approves them for that role and they sign off, maybe this could advance directly to 2.7?